### PR TITLE
Dont send personal information to Clicky and Google Analytics.

### DIFF
--- a/RealityCheck/misc.py
+++ b/RealityCheck/misc.py
@@ -1,0 +1,7 @@
+def clicky_anonymize(request):
+    # see https://clicky.com/help/custom
+    return {
+        'clicky_cookies_disable': 1,
+        # no popups, no consent
+        'clicky_visitor_consent': 0,
+    }

--- a/RealityCheck/settings.py
+++ b/RealityCheck/settings.py
@@ -38,6 +38,7 @@ TEMPLATES = [
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
+                'RealityCheck.misc.clicky_anonymize',
             ],
         },
     },

--- a/RealityCheck/settings.py
+++ b/RealityCheck/settings.py
@@ -103,6 +103,8 @@ USE_TZ = True
 CLICKY_SITE_ID='00000000'
 GOOGLE_ANALYTICS_PROPERTY_ID='UA-000000-0'
 GOOGLE_ANALYTICS_SITE_SPEED=False
+GOOGLE_ANALYTICS_ANONYMIZE_IP=True
+# analytical doesn't let us disable cookies
 
 try:
     from .settings_production import *

--- a/blog/templates/blog/header.html
+++ b/blog/templates/blog/header.html
@@ -28,6 +28,13 @@
      {% endif %}
   </title>
   {% clicky %}
+  <script type="text/javascript">
+  // set GA parameters before loading GA
+  var _gaq = _gaq || [];
+  // sadly, this seems to be the only way
+  // to make (legacy) ga.js not store any cookies
+  _gaq.push(['_setDomainName', 'example.invalid']);
+  </script>
   {% google_analytics %}
   </head>
   <body>


### PR DESCRIPTION
You don't load any social media sites' scripts and don't store any IP addresses locally (or use identifiable cookies).

So, the only personal information you are handling is via Clicky and Google Analytics.

 * Clicky has [this FAQ entry](https://clicky.com/help/faq/privacy/gdpr) (which is a bit ridiculous if you ask me), but makes it pretty easy to disable the use of cookies and gathering personal information in general.
 * Google Analytics makes this stuff generally easy, too. But you're using the legacy library (because analytical didn't upgrade), so things get a bit messy.

I confirmed that there a no more cookies being stored.
I didn't confirm whether tracking still works. :)

(And IANAL, of course.)